### PR TITLE
Font Formatting for Addresses

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -22,7 +22,6 @@
     <meta name="twitter:card" content="summary_large_image">
     
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@100;200;300;400;500;600;700&display=swap" rel="stylesheet">
 
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -21,7 +21,9 @@
     <meta name="twitter:image" content="%PUBLIC_URL%/opengraph.png">
     <meta name="twitter:card" content="summary_large_image">
     
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -20,10 +20,10 @@
 
     <meta name="twitter:image" content="%PUBLIC_URL%/opengraph.png">
     <meta name="twitter:card" content="summary_large_image">
-    
+
     <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin> 
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
 
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3,7 +3,7 @@
 }
 
 * {
-  font-family: 'Poppins', sans-serif;
+  font-family: 'Space Mono', sans-serif;
 }
 
 body {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3,7 +3,7 @@
 }
 
 * {
-  font-family: 'Space Mono', sans-serif;
+  font-family: 'Poppins', sans-serif;
 }
 
 body {

--- a/frontend/src/components/Table/HolderTable.js
+++ b/frontend/src/components/Table/HolderTable.js
@@ -80,11 +80,15 @@ const HolderTable = ({ badge }) => {
                         <TableRow
                             key={user.ethereum_address +'-'+ index}
                         >
-                            <TableCell component="th" scope="row" className="form__list__address">
-                                {user.ethereum_address}
+                            <TableCell component="th" scope="row">
+                                <div className="form__list__address">
+                                    {user.ethereum_address}
+                                </div>
                             </TableCell>
                             <TableCell component="th" scope="row">
-                                {user?.ens_name}
+                                <div>
+                                    {user?.ens_name}
+                                </div>
                             </TableCell>
                             <TableCell>
                                 <div className={`delegate__status__${user?.holder ? 'true' : 'false'}`}>

--- a/frontend/src/style/Dashboard/Form/Input.css
+++ b/frontend/src/style/Dashboard/Form/Input.css
@@ -54,3 +54,7 @@ input:disabled {
     font-variant-numeric: tabular-nums lining-nums;
     text-transform: uppercase;
 }
+
+.form__list__address {
+    font-family: monospace;
+}

--- a/frontend/src/style/Dashboard/Form/Input.css
+++ b/frontend/src/style/Dashboard/Form/Input.css
@@ -51,7 +51,6 @@ input:disabled {
 }
 
 .form__list__address {
-    font-family: 'Roboto Mono', monospace !important;
-    font-weight: 200 !important;
-    /* font-variant-numeric: tabular-nums lining-nums; */
+    font-variant-numeric: tabular-nums lining-nums;
+    text-transform: uppercase;
 }


### PR DESCRIPTION
Had let this slip into my address validation branch so I reverted the change in this branch.

This is with all upper case Poppins with tabular:
![Screen Shot 2022-10-18 at 4 44 00 PM](https://user-images.githubusercontent.com/33527785/196550829-1a4e4f1a-cc74-4b15-91db-c97e48a35075.png)

Regular casing: 
![Screen Shot 2022-10-18 at 5 00 01 PM](https://user-images.githubusercontent.com/33527785/196553162-c27f8841-5dd4-4906-8d7c-f798aa3f4513.png)

Roboto Mono:
![Screen Shot 2022-10-18 at 4 44 00 PM](https://user-images.githubusercontent.com/33527785/196523611-b2079242-e933-409f-a049-e9d5efc52bf8.png)


