### PR TITLE
Buffer resolution for WalletConnect

### DIFF
--- a/frontend/craco.config.js
+++ b/frontend/craco.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const Dotenv = require('dotenv-webpack');
+const { ProvidePlugin } = require('webpack');
 
 module.exports = {
     webpack: {
@@ -29,6 +30,9 @@ module.exports = {
               path: '../.env',
               safe: true,
               ignoreStub: true,
+            }),
+            new ProvidePlugin({
+                Buffer: ['buffer', 'Buffer']
             })
         ],
         configure: {
@@ -42,6 +46,11 @@ module.exports = {
                 );
               },
             ],
+            resolve: {
+                fallback: {
+                    buffer: require.resolve('buffer')
+                }
+            }
         },
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "buffer": "^6.0.3",
         "dotenv": "^16.0.3",
         "dotenv-webpack": "^8.0.1",
         "ethers": "^5.5.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "buffer": "^6.0.3",
     "dotenv": "^16.0.3",
     "dotenv-webpack": "^8.0.1",
     "ethers": "^5.5.1",


### PR DESCRIPTION
This PR fixes a module import conflict with Buffer, a dependency of WalletConnect.

Webpack5 removed polyfilled modules and broke a lot of node packages with the change. Using CRACO's configuration for webpack, we can provide fallback modules when a package is not configured to be used with Webpack5.