### PR TITLE
Add tutorial video to dashboard home

### DIFF
--- a/frontend/src/components/Dashboard/Home/Home.js
+++ b/frontend/src/components/Dashboard/Home/Home.js
@@ -6,6 +6,8 @@ import Card from "@components/Card/Card"
 import { HOME_LINKS } from "@static/constants/links";
 import { UserContext } from "@components/Dashboard/Provider/UserContextProvider";
 
+import video from '../../../static/images/tutorial.mp4'
+
 import "@style/Dashboard/Home/Home.css"
 
 const Home = () => {
@@ -23,7 +25,7 @@ const Home = () => {
 
     const onEnter = () => {
         authenticationError ?
-              tryAuthentication()
+            tryAuthentication()
             : navigate("/dashboard/organization/new")
     }
 
@@ -31,7 +33,7 @@ const Home = () => {
         <div className="home">
             <div className="home__announcement">
                 <Card className="announcement">
-                    <div className="announcement__status" style={{ 
+                    <div className="announcement__status" style={{
                         backgroundColor: announcement.color
                     }}></div>
                     {announcement.message}
@@ -42,15 +44,9 @@ const Home = () => {
                 <div className="home__cards__column">
                     <Card>
                         <div className="card__video">
-                            <iframe
-                                width="100%"
-                                height="300"
-                                src="https://www.youtube-nocookie.com/embed/C1ofCsq75GY"
-                                title="Live Walkthrough Video"
-                                allow="accelerometer; picture-in-picture"
-                                frameBorder={0}
-                                allowFullScreen={true}
-                            ></iframe>
+                            <video width="100%" controls >
+                                <source src={video} type="video/mp4" />
+                            </video>
                         </div>
                         <div className="home__card__content">
                             <FontAwesomeIcon icon={['fal', 'play']} />
@@ -88,10 +84,10 @@ const Home = () => {
                                 </div>
                             </div>
                         </Link> */}
-                        <button className="button__unstyled link-wrapper home-link" onClick={() => onEnter()} style={{fontWeight: "400"}}>
+                        <button className="button__unstyled link-wrapper home-link" onClick={() => onEnter()} style={{ fontWeight: "400" }}>
                             <div className="home__card__content">
                                 <FontAwesomeIcon icon={['fal', 'sitemap']} />
-                                {userData?.organizations?.length > 0 ? 
+                                {userData?.organizations?.length > 0 ?
                                     <div>
                                         <h2>Manage your Organizations</h2>
                                         <p>The credentials of your Organization are under your full control. Edit, Mint, Revoke, and Manage at will.</p>
@@ -107,8 +103,8 @@ const Home = () => {
                     </Card>
 
                     <Card>
-                        <a className="link-wrapper home-link" 
-                            href={ HOME_LINKS.gitbook } 
+                        <a className="link-wrapper home-link"
+                            href={HOME_LINKS.gitbook}
                             target="_blank" rel="noreferrer"
                         >
                             <div className="home__card__content">
@@ -122,8 +118,8 @@ const Home = () => {
                     </Card>
 
                     <Card>
-                        <a className="link-wrapper home-link" 
-                            href={ HOME_LINKS.github } 
+                        <a className="link-wrapper home-link"
+                            href={HOME_LINKS.github}
                             target="_blank" rel="noreferrer"
                         >
                             <div className="home__card__content">

--- a/frontend/src/style/Dashboard/Home/Home.css
+++ b/frontend/src/style/Dashboard/Home/Home.css
@@ -37,7 +37,6 @@
 
 .home__cards .card__video { 
     background: #000;
-    min-height: 300px;
     margin-bottom: 20px;
 }
 


### PR DESCRIPTION
This PR introduces the addition of the video to the Home dashboard. It is not on YouTube, as we want to be sure that people do not get distracted and solely focus on the video they are watching. It is, after all, a persistent tutorial.

The website is ready however, we have sent the video back for another round of edits. Once ready, the video needs to be dropped in, and this can be merged.