### PR TITLE
Only show badges and badge actions with the right permissions

### DIFF
--- a/frontend/src/components/Dashboard/Org/Badge.js
+++ b/frontend/src/components/Dashboard/Org/Badge.js
@@ -33,6 +33,9 @@ const Badge = () => {
     const badgeIndex = orgData?.badges?.findIndex(badge => badge.id === parseInt(badgeId));
     const [ badge, setBadge ] = useState(orgData?.badges?.[badgeIndex] || {});
     const isOwner = orgData?.owner?.ethereum_address === address;
+    // find if the authenticated address is in one of the delegates.ethereum_address properties
+    const isManager = badge?.delegates?.find(delegate => delegate.ethereum_address === address);
+
 
     const setDelegates = useSetDelegates(
         txCalled && isOwner,
@@ -50,11 +53,11 @@ const Badge = () => {
         1                                   // amount of each token
     );
 
-    const actions = [{
+    const actions = isOwner || isManager ? [{
         text: "Manage",
         icon: ["fal", "fa-person"],
         event: () => setIsManage(!isManage)
-    }]
+    }] : [];
 
     // Limit actions for Managers.
     const selectActions = isOwner ? [
@@ -167,8 +170,6 @@ const Badge = () => {
         setTxPending(false);
     }, [txMethod, setDelegates, manageOwnership, setError, onMembersUpdate, onDelegatesUpdate]);
 
-    // TODO: I don't like this method of mixing the transactions after getting here. This is due
-    //       a refactor that breaks each method out into its own flow.
     // If the transaction has been called, is not pending, and one of the transactions are prepped,
     // run the transaction.
     useEffect(() => {        
@@ -196,7 +197,7 @@ const Badge = () => {
                     <h1>{badge?.name}</h1>
                 </div>
 
-                {isManage && 
+                {isManage && (isOwner || isManager) &&
                     <>
                         <Select 
                             label="Update Type"
@@ -225,7 +226,7 @@ const Badge = () => {
                     <HolderTable badge={badge} />
                 }
 
-                {(!badge?.users || badge?.users?.length < 1) && !isManage && 
+                {(!badge?.users || badge?.users?.length < 1) && (isManager || isOwner) &&
                     <div className="org__container empty">
                         <h1>Your Organization is almost alive, it just needs members!</h1>
                         <p>

--- a/frontend/src/components/Dashboard/Provider/UserContextProvider.js
+++ b/frontend/src/components/Dashboard/Provider/UserContextProvider.js
@@ -111,7 +111,8 @@ const UserContextProvider = ({ children, signer }) => {
     return (
         <UserContext.Provider value={{
             userData, 
-            setUserData, 
+            setUserData,
+            authenticatedAddress,
             isAuthenticated, 
             tryAuthentication,
         }}>


### PR DESCRIPTION
Addressed this on the front end via changing org data to not be it's own request and instead pull from the user data request.

Then, once the authenticated address is set or changed, or the badge id in the url path changes, we take the org from the user data and change the org data's badges to only reflect badges that the user holds or is a manager of.

On the Badge page, we then check to see if they are the Owner of the org, or a Manager of this badge. If they are an owner, we give them the option to add and revoke managers. If they are just a manager, they only see mint and revoke. Finally, if they are neither, we hide the Manage button and drawer and all they can see is the badge name and holder table.

This change cleaned up OrgDataProvider, but has kind of bloated Badge.js. This should be fixed in the v5 changes when we redesign the page. I will make sure that each drawer gets broken out into its own component and state instead of all living in the base Badge.js