### PR TITLE
feat: use of official domain

### DIFF
--- a/api/api/settings/production.py
+++ b/api/api/settings/production.py
@@ -19,10 +19,12 @@ PROPAGATE_EXCEPTIONS = True
 X_FRAME_OPTIONS = "DENY"
 
 CORS_ORIGIN_ALLOW_ALL = True
-CSRF_TRUSTED_ORIGINS = ["https://badger.utc24.io"]
+CSRF_TRUSTED_ORIGINS = [
+    "https://trybadger.com"
+]
 
-CSRF_COOKIE_DOMAIN = ".badger.utc24.io"
-SESSION_COOKIE_DOMAIN = ".badger.utc24.io"
+CSRF_COOKIE_DOMAIN = ".trybadger.com"
+SESSION_COOKIE_DOMAIN = ".trybadger.com"
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
This PR is to update the domain configuration to enable the use of the newly deployed machines and domain systems. This is the last piece needed to disable the active routes living on [utc24.io](https://utc24.io).

https://trybadger.com
https://api.trybadger.com