### PR TITLE
Checksumming Addresses

### DIFF
--- a/frontend/src/components/Dashboard/Badge/Badge.js
+++ b/frontend/src/components/Dashboard/Badge/Badge.js
@@ -207,7 +207,8 @@ const Badge = () => {
                             style={{margin: "20px 0px 20px auto"}}
                             loading={txPending}
                             disabled={txMethod === "manageOwnership" ? 
-                                !manageOwnership.isSuccess : !setDelegates.isSuccess
+                                !manageOwnership.isSuccess || !areAddressesValid : 
+                                setDelegates.isSuccess || !areAddressesValid
                             }
                         />
                     </>

--- a/frontend/src/components/Dashboard/Badge/BadgeForm.js
+++ b/frontend/src/components/Dashboard/Badge/BadgeForm.js
@@ -134,12 +134,24 @@ const BadgeForm = () => {
         setBadgeImagePreview(URL.createObjectURL(image));
     }
 
-    // When the signer address is not focused, validate the address.
-    const onSignerBlur = (event) => {
-        const address = event.target.value;
+    // On signer change check if the signer is valid and if they are checksum the address.
+    const onSignerChange = (event) => {
+        const address = event.target.value.trim();
+        badgeDispatch({type: "SET", field: "signer", payload: address});
+
+        // An empty address is valid as it is caught in the contract hooks.
+        if (address === "") {
+            setSignerIsValid(true);
+            return;
+        }
+        // Save an RPC call if the address is not correct length.
+        if (address.length !== 42) {
+            setSignerIsValid(false);
+            return;
+        }
+
         const isValid = ethers.utils.isAddress(address);
-        if (address && !isValid) setSignerIsValid(false);
-        else setSignerIsValid(true);
+        setSignerIsValid(isValid);
     }
 
     // Write to contract
@@ -312,10 +324,7 @@ const BadgeForm = () => {
                     placeholder="0x0000..."
                     required={false}
                     value={badge.signer}
-                    onChange={(event) => badgeDispatch(
-                        {type: "SET", field: "signer", payload: event.target.value}    
-                    )}
-                    onBlur={onSignerBlur}
+                    onChange={(event) => onSignerChange(event)}
                 />
                 <InputListCSV
                     label={"Managers"}

--- a/frontend/src/utils/api_requests.js
+++ b/frontend/src/utils/api_requests.js
@@ -1,5 +1,5 @@
 import { IPFS_GATEWAY_URL } from "@static/constants/links"
-import { cleanAddresses, getCSRFToken, getFileFromBase64 } from "./helpers";
+import { formatAddresses, getCSRFToken, getFileFromBase64 } from "./helpers";
 
 const API_URL = process.env.REACT_APP_API_URL;
 
@@ -69,22 +69,9 @@ export async function postOrgRequest(org) {
 
 export async function postBadgeRequest(badge) {
     let response;
-    // Have to clean input addresses to match the API
-    const users = badge.users?.length > 0 ? 
-        badge.users.map(user => {
-            if (user.ethereum_address)
-                return user
-            return {ethereum_address: user}
-        })
-        : [];
-
-    const delegates = badge.delegates?.length > 0 ? 
-        badge.delegates.map(delegate => {
-            if (delegate.ethereum_address) 
-                return delegate
-            return {ethereum_address: delegate}
-        })
-        : [];
+    
+    const users = formatAddresses(badge.users);
+    const delegates = formatAddresses(badge.delegates);
 
     const organization = typeof(badge?.organization) === "string" ? 
           parseInt(badge?.organization) 
@@ -279,8 +266,8 @@ export async function putBadgeRolesRequest(badge, orgId) {
     let response;
 
     // Have to clean input addresses to match the API
-    const users = cleanAddresses(badge.users);
-    const delegates = cleanAddresses(badge.delegates);
+    const users = formatAddresses(badge.users);
+    const delegates = formatAddresses(badge.delegates);
     const organization = typeof(orgId) === "string" ? parseInt(orgId) : orgId;
 
     const data = {

--- a/frontend/src/utils/api_requests.js
+++ b/frontend/src/utils/api_requests.js
@@ -1,4 +1,5 @@
 import { IPFS_GATEWAY_URL } from "@static/constants/links"
+import { ethers } from "ethers";
 import { formatAddresses, getCSRFToken, getFileFromBase64 } from "./helpers";
 
 const API_URL = process.env.REACT_APP_API_URL;
@@ -72,6 +73,7 @@ export async function postBadgeRequest(badge) {
     
     const users = formatAddresses(badge.users);
     const delegates = formatAddresses(badge.delegates);
+    const signer = badge.signer === "" ? "" : ethers.utils.getAddress(badge.signer);
 
     const organization = typeof(badge?.organization) === "string" ? 
           parseInt(badge?.organization) 
@@ -85,7 +87,7 @@ export async function postBadgeRequest(badge) {
         image_hash: badge.image_hash,
         token_uri: badge.token_uri,
         account_bound: badge.account_bound,
-        signer_ethereum_address: "",
+        signer_ethereum_address: signer,
         users: users,
         delegates: delegates,
         organization: organization

--- a/frontend/src/utils/helpers.js
+++ b/frontend/src/utils/helpers.js
@@ -1,3 +1,6 @@
+import { ethers } from "ethers";
+
+// Turns a CSV file of addresses into an array.
 export const csvFileToArray = (file) => {
     const csvHeader = file.slice(0, file.indexOf("\n")).split(",");
     const csvRows = file.slice(file.indexOf("\n") + 1).split("\n");
@@ -27,12 +30,14 @@ export const compareByProperty = (property, direction, a, b) => {
     return 0;
 }
 
-export const cleanAddresses = (addresses) => {
-    return addresses.length > 0 ? 
+export const formatAddresses = (addresses) => {
+    return addresses?.length > 0 ? 
         addresses.map(user => {
-            if (user.ethereum_address)
+            if (user.ethereum_address) {
+                user.ethereum_address = ethers.utils.getAddress(user.ethereum_address);
                 return user
-            return {ethereum_address: user}
+            }
+            return {ethereum_address: ethers.utils.getAddress(user)}
         })
         : [];
 }


### PR DESCRIPTION
This PR fixes the checksumming issues between the front end and backend. Decided against forcing their input to be altered into a check sum as it fundamentally does nothing different for us and could end up causing a little confusion (and saves us a lot of RPC calls). We do make sure the addresses are valid so as long as they are giving us valid addresses, they will be checksummed before being consumed by the backend.

We should not need check sums on the backend for now as the main issue was posting to the database with users/delegates that were not checksum and the indexer would create a new instance of the user with their check summed address. Once we get people interfacing with our backend then it may be worthwhile to handle it there anytime a new wallet model is created.

Also cleaned up when the validating error appear as well as disabling buttons if addresses are invalid.