### PR TITLE
fix: og image bug

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -12,13 +12,12 @@
     <link rel="icon" href="%PUBLIC_URL%/badger-favicon.ico" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
-
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="%PUBLIC_URL%/opengraph.png" />
+    <meta property="og:image" content="http://www.trybadger.com/opengraph.png" />
     <meta property="og:image:width" content="1920" />
     <meta property="og:image:height" content="1080" />
 
-    <meta name="twitter:image" content="%PUBLIC_URL%/opengraph.png">
+    <meta name="twitter:image" content="http://www.trybadger.com/opengraph.png">
     <meta name="twitter:card" content="summary_large_image">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
Hi, this fixes this issue by using complete URLs.

<img width="600" alt="Screen Shot 2023-01-17 at 6 24 04 PM" src="https://user-images.githubusercontent.com/22061495/213045857-cd29ef4d-38e7-4489-bf7a-a5ef7b25b9f6.png">

The meta tags are read as content rather than href, meaning we have to provide the full URL. I knew this mistake on my part.