### PR TITLE
fix: changing connected wallets

### DIFF
--- a/frontend/src/components/Dashboard/DashboardLoader.js
+++ b/frontend/src/components/Dashboard/DashboardLoader.js
@@ -95,8 +95,6 @@ const DashboardLoader = ({
         }
 
         const getLogs = () => {
-            console.log('get logs')
-
             const filter = getFilter();
 
             const provider = getProvider(chainId);
@@ -112,17 +110,15 @@ const DashboardLoader = ({
         getLogs();
     }, [chainId, orgAddress, badgeId, managed, isLoading])
 
-    useEffect(() => {
-        if (!isLoading && (logs.length > 0 || !managed)) return
+    const isLogged = logs.length > 0;
 
+    useEffect(() => {
         if (!retrieve) return
 
-        console.log('retrieving', logs)
-
         retrieve();
-    }, [isLoading, logs])
+    }, [address, isLoading, isLogged, retrieve])
 
-    const isDeployed = !isLoading || logs.length > 0;
+    const isDeployed = !isLoading || isLogged;
 
     const isAccessible = !managed || managed && canManage;
 

--- a/frontend/src/hooks/useSocket.js
+++ b/frontend/src/hooks/useSocket.js
@@ -2,9 +2,13 @@ import { useEffect, useMemo, useState } from 'react';
 
 import ReconnectingWebSocket from 'reconnecting-websocket';
 
+import { useAccount } from "wagmi";
+
 import { useLogout } from "@hooks";
 
 const useSocket = ({ enabled, url }) => {
+    const { address } = useAccount();
+
     const { logout } = useLogout();
 
     const [connected, setConnected] = useState(false);
@@ -91,6 +95,8 @@ const useSocket = ({ enabled, url }) => {
     useEffect(() => {
         if (!enabled) return;
 
+        setObjects(null);
+
         client.onopen = () => {
             client.send(JSON.stringify({
                 action: 'list',
@@ -104,7 +110,7 @@ const useSocket = ({ enabled, url }) => {
 
             handleAction(message);
         }
-    }, [enabled]);
+    }, [enabled, address]);
 
     return {
         connected,


### PR DESCRIPTION
Implements a simple fix where the leading organizations from the socket are dumped when the connected wallet is changed. By doing it this way, all child architecture will be handled in line without needing to manage the state upwards.