### PR TITLE
Account bound functionality

### DIFF
--- a/frontend/src/pages/Badge/BadgeForm.js
+++ b/frontend/src/pages/Badge/BadgeForm.js
@@ -28,7 +28,7 @@ import { IPFS_GATEWAY_URL } from '@static';
 
 import '@style/pages/BadgeForm.css';
 
-const BadgeFormContent = ({ chainId, orgAddress, organization, badges, badge, isEdit }) => {
+const BadgeFormContent = ({ chainId, orgAddress, organization, badges, badge, isEdit, initialAccountBoundState }) => {
     const imageInput = useRef();
 
     const navigate = useNavigate();
@@ -37,9 +37,9 @@ const BadgeFormContent = ({ chainId, orgAddress, organization, badges, badge, is
 
     const [image, setImage] = useState(null);
 
-    // TODO: This needs to be either added to the obj after
-    //       cleaning it up or everything else comes out.
-    const [isAccountBound, setIsAccountBound] = useState(true);
+    const [isAccountBound, setIsAccountBound] = useState(isEdit ? initialAccountBoundState : true);
+
+    const needToChangeAccountBound = isAccountBound !== initialAccountBoundState;
 
     const name = useDebounce(obj.name, 300);
 
@@ -71,7 +71,8 @@ const BadgeFormContent = ({ chainId, orgAddress, organization, badges, badge, is
         ...obj,
         uriHash: metadataHash,
         accountBound: isAccountBound,
-        isNew: !isEdit,
+        setAccountBound: needToChangeAccountBound,
+        isEdit: isEdit,
         tokenId,
     });
 
@@ -156,9 +157,10 @@ const BadgeFormContent = ({ chainId, orgAddress, organization, badges, badge, is
         <>
             <SEO
                 title={`
-            ${isEdit ? 'Update' : 'Create'} 
-            ${`${organization?.name} //` || ''}
-            ${name || 'Badge'} // Badger`}
+                    ${isEdit ? 'Update' : 'Create'} 
+                    ${`${organization?.name} //` || ''}
+                    ${name || 'Badge'} // Badger
+                `}
             />
 
             <h2>{isEdit ? 'Update' : 'Create'} Badge</h2>
@@ -246,13 +248,11 @@ const BadgeForm = ({ isEdit = false }) => {
 
     const { chainId, orgAddress, badgeId } = useParams();
 
-    const { address, organization, badges, badge, hooks, canManage, retrieve } = useUser({
+    const { address, organization, badges, badge, canManage, retrieve, isAccountBound } = useUser({
         chainId,
         orgAddress,
         badgeId,
     });
-
-    console.log('hooks', hooks);
 
     return (
         <>
@@ -284,6 +284,7 @@ const BadgeForm = ({ isEdit = false }) => {
                     organization={organization}
                     badges={badges}
                     badge={badge}
+                    initialAccountBoundState={isAccountBound}
                     isEdit={isEdit}
                 />
             </DashboardLoader>

--- a/frontend/src/static/constants/constants.js
+++ b/frontend/src/static/constants/constants.js
@@ -46,31 +46,14 @@ const getRandomEmoji = (address) => {
     return pfpEmojis[randomIndex];
 }
 
-const BADGE_HEAD_ROWS = {
-    name: {
-        label: 'Badge',
-        sortable: true,
-        method: "",
-        align: 'left',
-        width: '50%',
-    },
-    holders: {
-        label: 'Holders',
-        sortable: true,
-        method: "",
-        align: 'left',
-        width: '10%',
-    },
-    updated: { 
-        label: 'Last Updated',
-        sortable: true,
-        method: "",
-        align: 'right',
-        width: '40%',
-    }
+const CONTRACT_SLOTS = {
+    BEFORE_FORFEIT: "0x4279a522786317da581eebbb5940c30b3f35c9249f7025aa9402e41f938a3e09",
+    BEFORE_MINT: "0xfd130903f7e993641fb78383cfbfd0cbb85e8cd82c74361e6d973ff9070c741f", BEFORE_REVOKE: "0x8f814277fd68c4b9529a6563dc634db1da8f31cc86eae42fedf19e7ff6549714", BEFORE_SET_HOOK: "0x9267ca31dfa08e6482d75d2d7e8dd2a493dd988cc342c41c9fc33fc40fd0ddbd",
+    BEFORE_TRANSFER: "0x844bb459abe62f824043e42caa262ad6859731fc48abd8966db11d779c0fe669"
 }
 
 export { 
     pfpEmojis,
-    getRandomEmoji
+    getRandomEmoji,
+    CONTRACT_SLOTS
 }

--- a/frontend/src/static/constants/index.js
+++ b/frontend/src/static/constants/index.js
@@ -1,3 +1,3 @@
-export { pfpEmojis, getRandomEmoji } from './constants'
+export { pfpEmojis, getRandomEmoji, CONTRACT_SLOTS } from './constants'
 export { ERRORS } from './errors'
 export { HOME_LINKS, IPFS_GATEWAY_URL, CHAIN_EXPLORER_URLS } from './links'

--- a/frontend/src/static/index.js
+++ b/frontend/src/static/index.js
@@ -1,4 +1,4 @@
-export { pfpEmojis, getRandomEmoji, ERRORS, HOME_LINKS, IPFS_GATEWAY_URL, CHAIN_EXPLORER_URLS } from './constants'
+export { pfpEmojis, getRandomEmoji, CONTRACT_SLOTS, ERRORS, HOME_LINKS, IPFS_GATEWAY_URL, CHAIN_EXPLORER_URLS } from './constants'
 
 export { default as ImageErrorFallback } from './images/imgerror.svg'
 export { default as logo } from './images/logo.png'


### PR DESCRIPTION
ISSUES
- Hit an issue with the Hook objects in the database being overwritten. If token_id 0 had an account bound hook, and token_id 1 is then configured to be account bound as well, then the indexer overwrites that existing Hook object with the new config that contains the token ID. 
  - The execute() function in BadgerTransferBound.sol shows how token IDs are packed in the same hook

```
/**
     * See {ERC1155._beforeTokenTransfer}
     * @dev Enables the ability to have modules such as Account Bound, etc.
     */
    function _beforeTokenTransfer(
        address _operator,
        address _from,
        address _to,
        uint256[] memory _ids,
        uint256[] memory _amounts,
        bytes memory _data
    ) internal virtual override {
        /// @dev Before transferring, process any Organization hooks.
        _hook(
            BEFORE_TRANSFER,
            abi.encode(_operator, _from, _to, _ids, _amounts, _data)
        );

        /// @dev Do not call the super as it is an empty function.
    }
```
So this fat list of args gets passed to _hook, and then _execute, as the data param. 

BadgerTransferBound decodes is as:
```
    /**
     * See {IBadgerHook-execute}.
     */
    function execute(bytes calldata _data) public virtual override {
        /// @dev Decode the transfer data forwarded from the Organization.
        (
            address _operator,
            address _from,
            address _to,
            uint256[] memory _ids,
            ,

        ) = abi.decode(
                _data,
                (address, address, address, uint256[], uint256[], bytes)
            );
 ```